### PR TITLE
Share Gradle repositories

### DIFF
--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -1,6 +1,3 @@
 allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+    apply from: rootProject.file("repositories.gradle")
 }

--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -1,0 +1,4 @@
+repositories {
+    mavenCentral()
+    google()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,3 @@
-repositories {
-    google()
-    mavenCentral()
-}
-
 allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+    apply from: rootProject.file("build-tools/repositories.gradle")
 }


### PR DESCRIPTION
Instead of repeating the repositories every time, we can share them in a build script. This would be useful also if we'll need to add repositories to the `buildscript` block in future.