### PR TITLE
Apply Detekt in non-JVM Kotlin modules

### DIFF
--- a/build-tools/common/src/main/kotlin/aditogether/buildtools/utils/PluginManagerUtils.kt
+++ b/build-tools/common/src/main/kotlin/aditogether/buildtools/utils/PluginManagerUtils.kt
@@ -1,6 +1,7 @@
 package aditogether.buildtools.utils
 
 import org.gradle.api.Plugin
+import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.plugins.PluginManager
 
 /**
@@ -8,4 +9,17 @@ import org.gradle.api.plugins.PluginManager
  */
 inline fun <reified P : Plugin<*>> PluginManager.apply() {
     apply(P::class.java)
+}
+
+/**
+ * Invokes [PluginManager.withPlugin] for each plugin in the inputs.
+ * This is useful to apply the same action for a list of plugins.
+ */
+fun PluginManager.withPlugins(
+    first: String,
+    vararg others: String,
+    action: (AppliedPlugin) -> Unit
+) {
+    withPlugin(first, action)
+    others.forEach { plugin -> withPlugin(plugin, action) }
 }

--- a/build-tools/lint/src/main/kotlin/aditogether/buildtools/lint/LintPlugin.kt
+++ b/build-tools/lint/src/main/kotlin/aditogether/buildtools/lint/LintPlugin.kt
@@ -3,6 +3,7 @@ package aditogether.buildtools.lint
 import aditogether.buildtools.lint.util.detektPlugins
 import aditogether.buildtools.utils.apply
 import aditogether.buildtools.utils.libsCatalog
+import aditogether.buildtools.utils.withPlugins
 import aditogether.buildtools.utils.withType
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektPlugin
@@ -13,7 +14,11 @@ import org.gradle.api.Project
 class LintPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
-        target.pluginManager.withPlugin("kotlin") {
+        target.pluginManager.withPlugins(
+            "kotlin",
+            "kotlin-android",
+            "kotlin-multiplatform"
+        ) {
             // Detekt should be applied only on Kotlin modules.
             configureDetekt(target)
         }


### PR DESCRIPTION
This PR applies Detekt in non-JVM Kotlin modules.
I didn't add `kotlin-native-cocoapods` and `kotlin-js` in the list since we have not planned yet to use them.

@4face-studi0 @mcatta 