### PR TITLE
Do not run Detekt on deleted files in pre-commit

### DIFF
--- a/scripts/hooks/pre-commit.sh
+++ b/scripts/hooks/pre-commit.sh
@@ -25,7 +25,11 @@ main() {
     *.sh) bash_files+=("$abs_file_path") ;;
     *.kt) kt_files+=("$abs_file_path") ;;
     esac
-  done < <(git diff --cached --name-only -z -- "*.sh" "*.kt") # Filters files for perf reasons.
+  done < <(
+    # Filters files by extensions for perf reasons.
+    # Filters only added, modified and renamed files.
+    git diff --cached --name-only -z --diff-filter=AMR -- "*.sh" "*.kt"
+  )
 
   [[ ${#bash_files[@]} -gt 0 ]] && run_bash_linter "${bash_files[@]}"
   [[ ${#kt_files[@]} -gt 0 ]] && run_kotlin_linter "${kt_files[@]}"


### PR DESCRIPTION
The linters need to be executed only on added, modified and renamed files to avoid to run them on deleted files (this would end up in a failure) or to copied files (this is not necessary).