### PR TITLE
Add Android shared plugins

### DIFF
--- a/build-tools/android/build.gradle
+++ b/build-tools/android/build.gradle
@@ -5,6 +5,10 @@ apply plugin: "org.jetbrains.kotlin.jvm"
 
 gradlePlugin {
     plugins {
+        app {
+            id = 'aditogether.android.app'
+            implementationClass = 'aditogether.buildtools.android.AndroidAppPlugin'
+        }
         library {
             id = 'aditogether.android.library'
             implementationClass = 'aditogether.buildtools.android.AndroidLibraryPlugin'

--- a/build-tools/android/build.gradle
+++ b/build-tools/android/build.gradle
@@ -3,6 +3,15 @@ group = "aditogether.buildtools.android"
 apply plugin: "java-gradle-plugin"
 apply plugin: "org.jetbrains.kotlin.jvm"
 
+gradlePlugin {
+    plugins {
+        library {
+            id = 'aditogether.android.library'
+            implementationClass = 'aditogether.buildtools.android.AndroidLibraryPlugin'
+        }
+    }
+}
+
 dependencies {
     implementation project(':common')
     implementation project(':jvm')

--- a/build-tools/android/build.gradle
+++ b/build-tools/android/build.gradle
@@ -1,0 +1,11 @@
+group = "aditogether.buildtools.android"
+
+apply plugin: "java-gradle-plugin"
+apply plugin: "org.jetbrains.kotlin.jvm"
+
+dependencies {
+    implementation project(':common')
+    implementation project(':jvm')
+    implementation libs.gradle.android.api
+    implementation libs.gradle.kotlin
+}

--- a/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidAppPlugin.kt
+++ b/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidAppPlugin.kt
@@ -1,0 +1,24 @@
+package aditogether.buildtools.android
+
+import aditogether.buildtools.utils.apply
+import aditogether.buildtools.utils.configure
+import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Applies a shared configuration to Android app targets.
+ */
+@Suppress("unused")
+internal class AndroidAppPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.pluginManager.apply("com.android.application")
+        target.pluginManager.apply<AndroidPlugin>()
+
+        target.extensions.configure(::configureAndroidApplicationExtension)
+    }
+
+    private fun configureAndroidApplicationExtension(ext: ApplicationExtension) {
+        ext.defaultConfig.targetSdk = AndroidConfigs.TARGET_SDK
+    }
+}

--- a/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidConfigs.kt
+++ b/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidConfigs.kt
@@ -1,0 +1,11 @@
+package aditogether.buildtools.android
+
+/**
+ * Defines the shared configuration for Android targets.
+ */
+object AndroidConfigs {
+    const val COMPILE_SDK: Int = 33
+    const val MIN_SDK: Int = 23
+    const val TARGET_SDK: Int = 33
+    const val BUILD_TOOLS: String = "33.0.3"
+}

--- a/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidLibraryPlugin.kt
+++ b/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidLibraryPlugin.kt
@@ -1,0 +1,16 @@
+package aditogether.buildtools.android
+
+import aditogether.buildtools.utils.apply
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Applies a shared configuration to Android libraries targets.
+ */
+@Suppress("unused")
+internal class AndroidLibraryPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.pluginManager.apply("com.android.library")
+        target.pluginManager.apply<AndroidPlugin>()
+    }
+}

--- a/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidPlugin.kt
+++ b/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidPlugin.kt
@@ -1,0 +1,45 @@
+package aditogether.buildtools.android
+
+import aditogether.buildtools.jvm.JvmOptions
+import aditogether.buildtools.utils.apply
+import aditogether.buildtools.utils.configure
+import aditogether.buildtools.utils.withType
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+/**
+ * Applies a shared configuration to Android targets (apps, libraries, etc...).
+ */
+internal class AndroidPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.pluginManager.apply<KotlinAndroidPluginWrapper>()
+
+        target.tasks.withType<KotlinCompile> { task ->
+            // Can't use JVM toolchains yet on Android.
+            task.kotlinOptions.jvmTarget = JvmOptions.JAVA_VERSION.toString()
+            task.compilerOptions.allWarningsAsErrors.set(JvmOptions.WARNINGS_AS_ERRORS)
+        }
+
+        target.extensions.configure(::configureAndroidExtension)
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun configureAndroidExtension(ext: CommonExtension<*, *, *, *>) {
+        ext.buildToolsVersion = AndroidConfigs.BUILD_TOOLS
+        ext.compileSdk = AndroidConfigs.COMPILE_SDK
+        ext.defaultConfig.minSdk = AndroidConfigs.MIN_SDK
+
+        val javaVersion = JavaVersion.toVersion(JvmOptions.JAVA_VERSION)
+        ext.compileOptions.apply {
+            // Can't use JVM toolchains yet on Android.
+            sourceCompatibility = javaVersion
+            targetCompatibility = javaVersion
+        }
+
+        ext.lint.warningsAsErrors = true
+    }
+}

--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'build-tools'
 
+include 'android'
 include 'common'
 include 'jvm'
 include 'lint'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,9 @@ buildscript {
     apply from: rootProject.file("build-tools/repositories.gradle"), to: buildscript
 
     dependencies {
+        classpath libs.gradle.android
         classpath libs.gradle.kotlin
+        classpath libs.gradle.aditogether.android
         classpath libs.gradle.aditogether.jvm
         classpath libs.gradle.aditogether.lint
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
 
+gradle-aditogether-android = { module = "aditogether.buildtools.android:android" }
 gradle-aditogether-jvm = { module = "aditogether.buildtools.jvm:jvm" }
 gradle-aditogether-lint = { module = "aditogether.buildtools.lint:lint" }
 gradle-android = { module = "com.android.tools.build:gradle", version.ref = "gradleAndroidPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref
 gradle-aditogether-jvm = { module = "aditogether.buildtools.jvm:jvm" }
 gradle-aditogether-lint = { module = "aditogether.buildtools.lint:lint" }
 gradle-android = { module = "com.android.tools.build:gradle", version.ref = "gradleAndroidPlugin" }
+gradle-android-api = { module = "com.android.tools.build:gradle-api", version.ref = "gradleAndroidPlugin" }
 gradle-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 gradle-kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }


### PR DESCRIPTION
This PR adds the shared library and app Android plugins.
This contains the **minimum** configuration which surely needs be shared, hence these plugins will be improved in future (we can add everything we'll need to share in future when we'll have some features implemented, e.g. test configs).

I picked 23 as the min sdk version temporarily, it can be changed in future.