### PR TITLE
Add local Detekt rules to pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ local.properties
 .idea/vcs.xml
 .idea/workspace.xml
 
-# Detekt CLI files downloaded by `scripts/linters/download_detekt_cli.sh`.
+# Detekt CLI files downloaded by `scripts/linters/bump_detekt_cli.sh`.
 /detekt/bin

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -40,6 +40,12 @@ prompt_yes_no() {
   done
 }
 
+arr_join_to_str() {
+  local input_arr=("$@")
+  IFS=,
+  printf "%s" "${input_arr[*]}"
+}
+
 __print_prompt() {
   local tag=$1
   local msg=$2

--- a/scripts/hooks/pre-commit.sh
+++ b/scripts/hooks/pre-commit.sh
@@ -59,16 +59,12 @@ run_kotlin_linter() {
     print_error "$P_TAG" "detekt jars in 'detekt/bin' required to verify Kotlin files, have you run './scripts/tuner.sh'?"
     exit 1
   fi
-  kotlin_files=("$@")
-  detekt_input=$(
-    IFS=,
-    printf "%s" "${kotlin_files[*]}"
-  )
+  kotlin_files_input=$(arr_join_to_str "$@")
   java -jar "$detekt_cli_jar" \
     --plugins "$detekt_twitter_compose_jar,$detekt_formatting_jar" \
     --config "$detekt_dir/config.yml" \
     --jvm-target "1.8" \
-    --input "$detekt_input" || {
+    --input "$kotlin_files_input" || {
     print_error "$P_TAG" "kotlin lint checks failed, please check the errors and commit again"
     exit 1
   }

--- a/scripts/hooks/pre-commit.sh
+++ b/scripts/hooks/pre-commit.sh
@@ -56,6 +56,7 @@ run_kotlin_linter() {
   local detekt_plugins_jars=(
     "$detekt_bin_dir/detekt_formatting.jar"
     "$detekt_bin_dir/detekt_twitter_compose.jar"
+    "$detekt_dir/rules/build/libs/rules.jar"
   )
 
   local detekt_plugins_input kotlin_files_input

--- a/scripts/hooks/pre-commit.sh
+++ b/scripts/hooks/pre-commit.sh
@@ -71,7 +71,7 @@ run_kotlin_linter() {
   java -jar "$detekt_cli_jar" \
     --plugins "$detekt_plugins_input" \
     --config "$detekt_dir/config.yml" \
-    --jvm-target "1.8" \
+    --jvm-target "11" \
     --input "$kotlin_files_input" || {
     print_error "$P_TAG" "kotlin lint checks failed, please check the errors and commit again"
     exit 1

--- a/scripts/linters/bump_detekt_cli.sh
+++ b/scripts/linters/bump_detekt_cli.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 #
-# Downloads the necessary Detekt jars to perform checks without invoking Gradle.
+# Downloads or generates the necessary Detekt jars to perform checks without invoking Gradle.
 # This script will output in `detekt/bin/` which is excluded in our .gitignore.
 # The output is cached and will be invalidated only upon version changes.
-# The version is extracted from our Gradle Version Catalog (`gradle/libs.versions.toml`).
+# The remote jars versions are extracted from our Gradle Version Catalog (`gradle/libs.versions.toml`).
 # To force the invalidation you can invoke this script with the `force` argument:
 # `./scripts/detekt/bump_detekt_cli.sh force`
 #

--- a/scripts/linters/bump_detekt_cli.sh
+++ b/scripts/linters/bump_detekt_cli.sh
@@ -6,13 +6,13 @@
 # The output is cached and will be invalidated only upon version changes.
 # The version is extracted from our Gradle Version Catalog (`gradle/libs.versions.toml`).
 # To force the invalidation you can invoke this script with the `force` argument:
-# `./scripts/detekt/download_detekt_cli.sh force`
+# `./scripts/detekt/bump_detekt_cli.sh force`
 #
 
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "$SCRIPT_DIR/../common/common.sh"
 
-P_TAG="download-detekt-cli"
+P_TAG="bump-detekt-cli"
 
 ROOT_DIR="$SCRIPT_DIR/../.."
 VERSION_CATALOG_PATH="$ROOT_DIR/gradle/libs.versions.toml"
@@ -66,7 +66,7 @@ bump_detekt_jar() {
     read -r current_version <"$version_file"
   fi
   if [[ "$version" == "$current_version" ]]; then
-    print_info $P_TAG "$id $version already downloaded, skipping"
+    print_info $P_TAG "$id $version up-to-date"
   else
     print_info $P_TAG "downloading $id $version"
     download_file "$url" "$jar_file"

--- a/scripts/preconditions.sh
+++ b/scripts/preconditions.sh
@@ -10,7 +10,15 @@ source "$SCRIPT_DIR/common/common.sh"
 P_TAG="preconditions"
 
 main() {
+  check_os
   check_symlinks_resolver
+}
+
+check_os() {
+  if [[ "$OSTYPE" != "darwin"* && "$OSTYPE" != "linux"* ]]; then
+    print_error $P_TAG "tuner is available only on Linux and macOS"
+    exit 1
+  fi
 }
 
 check_symlinks_resolver() {

--- a/scripts/tuner.sh
+++ b/scripts/tuner.sh
@@ -12,7 +12,7 @@ P_TAG="tuner"
 # Scripts that need to be executed (the order is respected).
 TUNER_SCRIPTS=(
   "preconditions.sh"
-  "linters/download_detekt_cli.sh"
+  "linters/bump_detekt_cli.sh"
   "hooks/install-hooks.sh"
 )
 


### PR DESCRIPTION
This PR adds local jars to the pre-commit hook.
Also, from now on, the pre-commit hook will automatically download/generate the detekt jars if the cache is invalidated.

Closes: https://github.com/androiddevelopersitalia/aditogether/issues/29