### PR TITLE
Detekt forbidden local function rule

### DIFF
--- a/detekt/config.yml
+++ b/detekt/config.yml
@@ -974,3 +974,8 @@ TwitterCompose:
   # https://twitter.github.io/compose-rules/rules/#viewmodels
   ViewModelInjection:
     active: true
+
+AdiTogether:
+  active: true
+  ForbiddenLocalFunction:
+    active: true

--- a/detekt/rules/src/main/kotlin/aditogether/detekt/rules/AdiTogetherRuleSetProvider.kt
+++ b/detekt/rules/src/main/kotlin/aditogether/detekt/rules/AdiTogetherRuleSetProvider.kt
@@ -9,7 +9,9 @@ class AdiTogetherRuleSetProvider : RuleSetProvider {
     override val ruleSetId: String = "AdiTogether"
 
     override fun instance(config: Config) = RuleSet(
-        ruleSetId,
-        listOf()
+        id = ruleSetId,
+        rules = listOf(
+            ForbiddenLocalFunction()
+        )
     )
 }

--- a/detekt/rules/src/main/kotlin/aditogether/detekt/rules/ForbiddenLocalFunction.kt
+++ b/detekt/rules/src/main/kotlin/aditogether/detekt/rules/ForbiddenLocalFunction.kt
@@ -1,0 +1,57 @@
+package aditogether.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+/**
+ * Forbid local functions.
+ *
+ * Compliant code:
+ * ```kotlin
+ * fun foo() {
+ *     bar()
+ * }
+ *
+ * private fun bar() {
+ *     println("bar")
+ * }
+ * ```
+ *
+ * Non-compliant code:
+ * ```kotlin
+ * fun foo() {
+ *     fun bar() {
+ *         println("bar")
+ *     }
+ *     bar()
+ * }
+ */
+class ForbiddenLocalFunction : Rule() {
+
+    override val issue = Issue(
+        id = javaClass.simpleName,
+        severity = Severity.Minor,
+        description = DESCRIPTION,
+        debt = Debt.TEN_MINS
+    )
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+
+        if (function.isLocal) {
+            report(CodeSmell(issue, Entity.from(function), MESSAGE))
+        }
+    }
+
+    private companion object {
+
+        const val DESCRIPTION = "Local functions are forbidden."
+        const val MESSAGE = "Local function makes the code harder to read and understand. " +
+            "Consider extracting it to a regular private function."
+    }
+}

--- a/detekt/rules/src/test/kotlin/aditogether/detekt/rules/ForbiddenLocalFunctionTest.kt
+++ b/detekt/rules/src/test/kotlin/aditogether/detekt/rules/ForbiddenLocalFunctionTest.kt
@@ -1,0 +1,49 @@
+package aditogether.detekt.rules
+
+import io.gitlab.arturbosch.detekt.test.lint
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+
+class ForbiddenLocalFunctionTest : BehaviorSpec({
+
+    val rule = ForbiddenLocalFunction()
+
+    Given("a file with local functions") {
+        val code = """
+            fun foo() {
+                fun bar() {
+                    println("bar")
+                }
+                bar()
+            }
+        """.trimIndent()
+
+        When("linting the file") {
+            val findings = rule.lint(code)
+
+            Then("it should report a nested function") {
+                findings shouldHaveSize 1
+            }
+        }
+    }
+
+    Given("a file without local functions") {
+        val code = """
+            fun foo() {
+                bar()
+            }
+            
+            private fun bar() {
+                println("bar")
+            }
+        """.trimIndent()
+
+        When("linting the file") {
+            val findings = rule.lint(code)
+
+            Then("it should not report any nested functions") {
+                findings shouldHaveSize 0
+            }
+        }
+    }
+})

--- a/detekt/rules/src/test/kotlin/aditogether/detekt/rules/ForbiddenLocalFunctionTest.kt
+++ b/detekt/rules/src/test/kotlin/aditogether/detekt/rules/ForbiddenLocalFunctionTest.kt
@@ -21,7 +21,7 @@ class ForbiddenLocalFunctionTest : BehaviorSpec({
         When("linting the file") {
             val findings = rule.lint(code)
 
-            Then("it should report a nested function") {
+            Then("it should report a local function") {
                 findings shouldHaveSize 1
             }
         }
@@ -41,7 +41,24 @@ class ForbiddenLocalFunctionTest : BehaviorSpec({
         When("linting the file") {
             val findings = rule.lint(code)
 
-            Then("it should not report any nested functions") {
+            Then("it should not report any local functions") {
+                findings shouldHaveSize 0
+            }
+        }
+    }
+
+    Given("a file with lambda function inside a function") {
+        val code = """
+            fun foo() {
+                val bar = { println("bar") }
+                bar()
+            }
+        """.trimIndent()
+
+        When("linting the file") {
+            val findings = rule.lint(code)
+
+            Then("it should not report any local functions") {
                 findings shouldHaveSize 0
             }
         }

--- a/playground/build.gradle
+++ b/playground/build.gradle
@@ -1,1 +1,6 @@
 apply plugin: "aditogether.jvm"
+
+dependencies {
+    testImplementation libs.kotest.assertions
+    testImplementation libs.kotest.runner
+}


### PR DESCRIPTION
This PR closes #22 

NOTE: message is the screen is not updated, see from log below

**Non-compliant code in IDE**
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/37957092/218251751-ba37bfba-2a24-44b3-a7e1-fe8396aab414.png">

**Non-compiant code in Gradle**
> Task :playground:detekt FAILED
~ /AdiTogether/~/DetektPlayground.kt:8:5: Local function makes the code harder to read and understand. Consider extracting it to a regular private function. [ForbiddenLocalFunction]
AdiTogether - 10min debt

