### PR TITLE
Add multi-platform shared plugin

### DIFF
--- a/build-tools/multiplatform/build.gradle
+++ b/build-tools/multiplatform/build.gradle
@@ -3,6 +3,15 @@ group = "aditogether.buildtools.multiplatform"
 apply plugin: "java-gradle-plugin"
 apply plugin: "org.jetbrains.kotlin.jvm"
 
+gradlePlugin {
+    plugins {
+        multiplatform {
+            id = 'aditogether.multiplatform'
+            implementationClass = 'aditogether.buildtools.multiplatform.MultiPlatformPlugin'
+        }
+    }
+}
+
 dependencies {
     implementation project(':common')
     implementation project(':jvm')

--- a/build-tools/multiplatform/build.gradle
+++ b/build-tools/multiplatform/build.gradle
@@ -1,0 +1,10 @@
+group = "aditogether.buildtools.multiplatform"
+
+apply plugin: "java-gradle-plugin"
+apply plugin: "org.jetbrains.kotlin.jvm"
+
+dependencies {
+    implementation project(':common')
+    implementation project(':jvm')
+    implementation libs.gradle.kotlin
+}

--- a/build-tools/multiplatform/src/main/kotlin/aditogether/buildtools/multiplatform/MultiPlatformPlugin.kt
+++ b/build-tools/multiplatform/src/main/kotlin/aditogether/buildtools/multiplatform/MultiPlatformPlugin.kt
@@ -1,0 +1,37 @@
+package aditogether.buildtools.multiplatform
+
+import aditogether.buildtools.jvm.JvmOptions
+import aditogether.buildtools.utils.apply
+import aditogether.buildtools.utils.configure
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmTargetPreset
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
+
+/**
+ * Applies a shared Kotlin multi-platform configuration to the given project.
+ * This plugin supports the following compilation targets:
+ * - JVM
+ */
+@Suppress("unused")
+internal class MultiPlatformPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.pluginManager.apply<KotlinMultiplatformPluginWrapper>()
+
+        target.extensions.configure<KotlinMultiplatformExtension> { ext ->
+            ext.targetFromPreset(KotlinJvmTargetPreset(target), ::configureJvmTarget)
+        }
+    }
+
+    private fun configureJvmTarget(target: KotlinJvmTarget) {
+        target.compilations.all { compilation ->
+            compilation.compilerOptions.configure {
+                allWarningsAsErrors.set(JvmOptions.WARNINGS_AS_ERRORS)
+                jvmTarget.set(JvmTarget.fromTarget(JvmOptions.JAVA_VERSION.toString()))
+            }
+        }
+    }
+}

--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -4,6 +4,7 @@ include 'android'
 include 'common'
 include 'jvm'
 include 'lint'
+include 'multiplatform'
 
 dependencyResolutionManagement {
     versionCatalogs {

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         classpath libs.gradle.aditogether.android
         classpath libs.gradle.aditogether.jvm
         classpath libs.gradle.aditogether.lint
+        classpath libs.gradle.aditogether.multiplatform
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref
 gradle-aditogether-android = { module = "aditogether.buildtools.android:android" }
 gradle-aditogether-jvm = { module = "aditogether.buildtools.jvm:jvm" }
 gradle-aditogether-lint = { module = "aditogether.buildtools.lint:lint" }
+gradle-aditogether-multiplatform = { module = "aditogether.buildtools.multiplatform:multiplatform" }
 gradle-android = { module = "com.android.tools.build:gradle", version.ref = "gradleAndroidPlugin" }
 gradle-android-api = { module = "com.android.tools.build:gradle-api", version.ref = "gradleAndroidPlugin" }
 gradle-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }


### PR DESCRIPTION
This PR adds the shared Gradle plugin for Kotlin multi-platform modules.
Currently, it only supports JVM compilation targets (in future we can add iOS).