### PR TITLE
Forbid Kotest styles beside BehaviorSpec

### DIFF
--- a/detekt/config.yml
+++ b/detekt/config.yml
@@ -697,8 +697,8 @@ style:
     allowedPatterns: ''
   ForbiddenImport:
     active: true
-    imports: ['junit.framework.TestCase.*', 'org.junit.Assert.*', 'org.junit.framework.Assert.*', 'org.junit.Test']
-    forbiddenPatterns: ''
+    imports: []
+    forbiddenPatterns: 'io\.kotest\.core\.spec\.style\.(?!BehaviorSpec)'
   ForbiddenMethodCall:
     active: true
     methods: ['app.cash.sqldelight.Transacter.transaction', 'app.cash.sqldelight.Transacter.transactionWithResult']


### PR DESCRIPTION
This PR forbid usage of Kotest styles except `BehaviorSpec`

**Result in IDE**
<img width="787" alt="image" src="https://user-images.githubusercontent.com/37957092/218268424-a33d6ca2-b05c-4daa-b125-2f7d9e43956d.png">

The current regex forbids every import from `io.kotest.core.spec.style` besides `BehaviorSpec`. I wouldn't exclude that we will need more imports from the package, but not having a deeper knowledge about Kotest, I think we can start with this simple rule and revisit it later 

Closes #36 