### PR TITLE
Enable auto-correct with Detekt in pre-commit.sh

### DIFF
--- a/scripts/hooks/pre-commit.sh
+++ b/scripts/hooks/pre-commit.sh
@@ -69,6 +69,7 @@ run_kotlin_linter() {
   }
 
   java -jar "$detekt_cli_jar" \
+    --auto-correct \
     --plugins "$detekt_plugins_input" \
     --config "$detekt_dir/config.yml" \
     --jvm-target "11" \


### PR DESCRIPTION
This PR adds auto-correct with Detekt in pre-commit.sh.

When a commit is done and Detekt found issues on the committed files, it will try to correct them automatically, if possible.