### PR TITLE
Validate Git commit messages on CI

### DIFF
--- a/.github/workflows/push-workflow.yml
+++ b/.github/workflows/push-workflow.yml
@@ -9,6 +9,10 @@ on:
       - main
 
 jobs:
+  sanity-checks:
+    name: Run sanity checks
+    uses: ./.github/workflows/sanity-checks.yml
+    secrets: inherit
 
   lint:
     name: Run linters

--- a/.github/workflows/sanity-checks.yml
+++ b/.github/workflows/sanity-checks.yml
@@ -1,0 +1,23 @@
+name: Sanity checks
+
+on: workflow_call
+
+jobs:
+  validate-commit-messages:
+    name: Validate commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code - push
+        uses: actions/checkout@v3
+        if: ${{ github.event_name == 'push' }}
+      - name: Check out repository code - PR
+        uses: actions/checkout@v3
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          # This checks out the HEAD commit of the PR instead of the merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Fetches all the commits of the PR to validate them.
+          fetch-depth: ${{ github.event.pull_request.commits }}
+
+      - name: Validate commit messages
+        run: ./scripts/ci/validate-commit-messages.sh

--- a/scripts/ci/validate-commit-messages.sh
+++ b/scripts/ci/validate-commit-messages.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Verifies that the commits of our repo are following our commit convention.
+# More info can be found in `scripts/common/commit-msg-regex.sh`.
+# This script is designed to be used by our CI.
+#
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "$SCRIPT_DIR/../common/common.sh"
+source "$SCRIPT_DIR/../common/commit-msg-regex.sh"
+
+P_TAG="validate-commit-messages"
+
+main() {
+  if [[ -z "$COMMIT_MSG_REGEX" ]]; then
+      print_error $P_TAG "COMMIT_MSG_REGEX env var missing"
+      exit 1
+  fi
+
+  local invalid_commits
+  invalid_commits=$(git log --grep="$COMMIT_MSG_REGEX" -E --invert-grep --pretty="format:%s")
+  print_info $P_TAG "validating commit messages"
+  if [[ -z "$invalid_commits" ]]; then
+      print_success $P_TAG "all commit messages are valid"
+      exit 0
+  fi
+  print_error $P_TAG "the following commits are not valid"
+  echo "════════════════════════════════"
+  echo "$invalid_commits"
+  echo "════════════════════════════════"
+  exit 1
+}
+
+main

--- a/scripts/common/commit-msg-regex.sh
+++ b/scripts/common/commit-msg-regex.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Exposes the regex used to validate the Git commit message so it can be shared between scripts.
+# This regex is based on https://www.conventionalcommits.org/
+#
+# Examples of valid commit messages:
+# - chore: this is the message
+# - feat(news): this is the message
+# - refactor(news)!: this is the message
+#
+# Examples on invalid commit messages:
+# - chore:
+# - fix(): this is the message
+# - docs: This is the message
+# - random_keyword: this is the message
+export COMMIT_MSG_REGEX="^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)+(\([a-z0-9\-_\/]+\))?!?:\s[a-z][a-zA-Z0-9 -_\/\`]+$"

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
 
 #
-# Git commit-msg hook used to enforce the same commit convention (https://www.conventionalcommits.org/).
-#
-# Examples of valid commit messages:
-# - chore: this is the message
-# - feat(news): this is the message
-# - refactor(news)!: this is the message
-#
-# Examples on invalid commit messages:
-# - chore:
-# - fix(): this is the message
-# - docs: This is the message
-# - random_keyword: this is the message
+# Git commit-msg hook which enforces our commit convention.
+# More info can be found in `scripts/common/commit-msg-regex.sh`.
 #
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -21,12 +11,18 @@ else
   SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 fi
 source "$SCRIPT_DIR/../common/common.sh"
+source "$SCRIPT_DIR/../common/commit-msg-regex.sh"
 
 P_TAG="commit-msg hook"
 
 COMMIT_MSG_FILE=$1
 
 main() {
+  if [[ -z "$COMMIT_MSG_REGEX" ]]; then
+    print_error "$P_TAG" "COMMIT_MSG_REGEX env var missing"
+    exit 1
+  fi
+
   local lines_count
   lines_count=$(grep -c ^ "$COMMIT_MSG_FILE")
   if [[ $lines_count -gt 1 ]]; then
@@ -34,8 +30,7 @@ main() {
     exit 1
   fi
 
-  local pattern="^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)+(\([a-z0-9\-_\/]+\))?!?:\s[a-z][a-zA-Z0-9 -_\/\`]+$"
-  if ! grep -q -E "$pattern" "$COMMIT_MSG_FILE"; then
+  if ! grep -q -E "$COMMIT_MSG_REGEX" "$COMMIT_MSG_FILE"; then
     print_error "$P_TAG" "the commit message does not follow https://www.conventionalcommits.org/"
     exit 1
   fi


### PR DESCRIPTION
This PR enforces our Git commit convention on CI.
It also adds a new workflow called `sanity-checks` where we'll add other rules on our repo (e.g. forbidding some file types, adding validation on branches/tags and so on)