### PR TITLE
Force `all` distribution type for wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,3 +15,6 @@ allprojects {
     apply from: rootProject.file("build-tools/repositories.gradle")
     apply plugin: "aditogether.lint"
 }
+
+// Forces the download of Gradle Wrapper to access sources and improve auto-completion.
+wrapper.distributionType = Wrapper.DistributionType.ALL


### PR DESCRIPTION
This PR forces the download of the `-all` distribution of Gradle Wrapper to access Gradle sources and improve auto-completion.