### PR TITLE
Forbid *.gradle.kts files

### DIFF
--- a/.github/workflows/sanity-checks.yml
+++ b/.github/workflows/sanity-checks.yml
@@ -22,3 +22,13 @@ jobs:
 
       - name: Validate commit messages
         run: ./scripts/ci/validate-commit-messages.sh
+
+  check-invalid-files:
+    name: Check invalid files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Check invalid files
+        run: ./scripts/ci/check-invalid-files.sh

--- a/.github/workflows/sanity-checks.yml
+++ b/.github/workflows/sanity-checks.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Check out repository code - push
         uses: actions/checkout@v3
         if: ${{ github.event_name == 'push' }}
+
       - name: Check out repository code - PR
         uses: actions/checkout@v3
         if: ${{ github.event_name == 'pull_request' }}

--- a/scripts/ci/check-invalid-files.sh
+++ b/scripts/ci/check-invalid-files.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#
+# Checks that the repo does not contains ome forbidden files (e.g. *.gradle.kts files).
+# This script is designed to be used by our CI.
+#
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "$SCRIPT_DIR/../common/common.sh"
+
+P_TAG="check-invalid-files"
+
+main() {
+  print_info $P_TAG "checking if *.gradle.kts files are present"
+  local gradle_kts_files
+  gradle_kts_files=$(git ls-files "*.gradle.kts")
+  if [[ -z "$gradle_kts_files" ]]; then
+    print_success $P_TAG "no *.gradle.kts files found"
+    exit 0
+  fi
+  print_error $P_TAG "the following *.gradle.kts files are forbidden, please convert them to *.gradle files"
+  echo "════════════════════════════════"
+  echo "$gradle_kts_files"
+  echo "════════════════════════════════"
+  exit 1
+}
+
+main

--- a/scripts/hooks/pre-commit.sh
+++ b/scripts/hooks/pre-commit.sh
@@ -24,16 +24,22 @@ main() {
     case "$relative_file_path" in
     *.sh) bash_files+=("$abs_file_path") ;;
     *.kt) kt_files+=("$abs_file_path") ;;
+    *.gradle.kts) fail_on_gradle_kts_files ;;
     esac
   done < <(
     # Filters files by extensions for perf reasons.
     # Filters only added, modified and renamed files.
-    git diff --cached --name-only -z --diff-filter=AMR -- "*.sh" "*.kt"
+    git diff --cached --name-only -z --diff-filter=AMR -- "*.sh" "*.kt" "*.gradle.kts"
   )
 
   [[ ${#bash_files[@]} -gt 0 ]] && run_bash_linter "${bash_files[@]}"
   [[ ${#kt_files[@]} -gt 0 ]] && run_kotlin_linter "${kt_files[@]}"
   exit 0
+}
+
+fail_on_gradle_kts_files() {
+   print_error "$P_TAG" "*.gradle.kts files are forbidden, please convert them to *.gradle files"
+   exit 1
 }
 
 run_bash_linter() {


### PR DESCRIPTION
This PR adds the scripts to forbid `*.gradle.kts` as agreed already at the start.

Checks are performed both in the pre-commit hook and on our CI.