### PR TITLE
Add JVM toolchains resolver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ project.
 
 ### Set up the project ⚙️
 
-- Have a JDK >= 11 installed (even the bundled one with AS/IJ)
 - Clone the repository
 - Run `./scripts/tuner.sh` to set up the local tools used by this repository: this script will perform some
   environmental checks and help to follow our guidelines (e.g. installing Git hooks)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Adi Together
 
 ### Setup
-- Have a JDK >= 11 installed (even the bundled one with AS/IJ)
 - Run `./scripts/tuner.sh` to setup the local tools used by this repository
 
 ### Features

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 rootProject.name = "aditogether"
 
 includeBuild 'build-tools'


### PR DESCRIPTION
This PR adds a JVM toolchains resolver to download the right JVM toolchain if there's no matching toolchain installed.