### PR TITLE
Downgrade build tools to 33.0.2

### DIFF
--- a/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidConfigs.kt
+++ b/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidConfigs.kt
@@ -7,5 +7,5 @@ object AndroidConfigs {
     const val COMPILE_SDK: Int = 33
     const val MIN_SDK: Int = 23
     const val TARGET_SDK: Int = 33
-    const val BUILD_TOOLS: String = "33.0.3"
+    const val BUILD_TOOLS: String = "33.0.2"
 }


### PR DESCRIPTION
The latest Ubuntu GH runner doesn't support 33.0.3.