### PR TITLE
Improve JDK integration

### DIFF
--- a/.idea/runConfigurations/tuner.xml
+++ b/.idea/runConfigurations/tuner.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="tuner" type="ShConfigurationType">
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/scripts/tuner.sh" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ project.
 
 ### Set up the project ⚙️
 
+- Have a JDK >= 11 installed (even the bundled one with AS/IJ)
 - Clone the repository
 - Run `./scripts/tuner.sh` to set up the local tools used by this repository: this script will perform some
   environmental checks and help to follow our guidelines (e.g. installing Git hooks)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Adi Together
 
 ### Setup
+- Have a JDK >= 11 installed (even the bundled one with AS/IJ)
 - Run `./scripts/tuner.sh` to setup the local tools used by this repository
 
 ### Features

--- a/scripts/preconditions.sh
+++ b/scripts/preconditions.sh
@@ -12,6 +12,7 @@ P_TAG="preconditions"
 main() {
   check_os
   check_symlinks_resolver
+  check_java
 }
 
 check_os() {
@@ -27,6 +28,15 @@ check_symlinks_resolver() {
     exit 1
   else
     print_success $P_TAG "symlinks resolver available"
+  fi
+}
+
+check_java() {
+  if [[ -z "$JAVA_HOME" ]]; then
+    print_error $P_TAG "You need to set your JAVA_HOME"
+    exit 1
+  else
+    print_success $P_TAG "JAVA_HOME set correctly"
   fi
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+    def currentJavaVersion = JavaVersion.current()
+    if (!currentJavaVersion.isJava11Compatible()) {
+        throw new IllegalArgumentException("Java 11 is needed to compile the project. Current: $currentJavaVersion.")
+    }
+}
+
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
 }


### PR DESCRIPTION
This PR adds some small improvements for the final user to ensure that the right JDK version (>=11) is being used.
It also adds an IDE run configuration for `tuner.sh` so users who prefer to avoid the terminal, can use that one.