### PR TITLE
Share build-tools Gradle modules configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ local.properties
 
 # IntelliJ
 .idea/.name
+.idea/codeStyles
 .idea/compiler.xml
 .idea/gradle.xml
 .idea/jarRepositories.xml

--- a/build-tools/android/build.gradle
+++ b/build-tools/android/build.gradle
@@ -1,7 +1,6 @@
 group = "aditogether.buildtools.android"
 
 apply plugin: "java-gradle-plugin"
-apply plugin: "org.jetbrains.kotlin.jvm"
 
 gradlePlugin {
     plugins {

--- a/build-tools/android/build.gradle
+++ b/build-tools/android/build.gradle
@@ -17,7 +17,6 @@ gradlePlugin {
 
 dependencies {
     implementation project(':common')
-    implementation project(':jvm')
     implementation libs.gradle.android.api
     implementation libs.gradle.kotlin
 }

--- a/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidPlugin.kt
+++ b/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidPlugin.kt
@@ -1,13 +1,15 @@
 package aditogether.buildtools.android
 
-import aditogether.buildtools.jvm.JvmOptions
 import aditogether.buildtools.utils.apply
+import aditogether.buildtools.utils.boolProperty
 import aditogether.buildtools.utils.configure
+import aditogether.buildtools.utils.intProperty
 import aditogether.buildtools.utils.withType
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -18,22 +20,28 @@ internal class AndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.pluginManager.apply<KotlinAndroidPluginWrapper>()
 
+        val javaTarget = target.intProperty("aditogether.jvmOptions.javaTarget")
+        val warningsAsErrors = target.boolProperty("aditogether.jvmOptions.warningsAsErrors")
         target.tasks.withType<KotlinCompile> { task ->
             // Can't use JVM toolchains yet on Android.
-            task.kotlinOptions.jvmTarget = JvmOptions.JAVA_VERSION.toString()
-            task.compilerOptions.allWarningsAsErrors.set(JvmOptions.WARNINGS_AS_ERRORS)
+            task.compilerOptions {
+                jvmTarget.set(JvmTarget.valueOf(javaTarget.toString()))
+                allWarningsAsErrors.set(warningsAsErrors)
+            }
         }
 
-        target.extensions.configure(::configureAndroidExtension)
+        target.extensions.configure<CommonExtension<*, *, *, *>> { ext ->
+            configureAndroidExtension(ext, javaTarget)
+        }
     }
 
     @Suppress("UnstableApiUsage")
-    private fun configureAndroidExtension(ext: CommonExtension<*, *, *, *>) {
+    private fun configureAndroidExtension(ext: CommonExtension<*, *, *, *>, javaTarget: Int) {
         ext.buildToolsVersion = AndroidConfigs.BUILD_TOOLS
         ext.compileSdk = AndroidConfigs.COMPILE_SDK
         ext.defaultConfig.minSdk = AndroidConfigs.MIN_SDK
 
-        val javaVersion = JavaVersion.toVersion(JvmOptions.JAVA_VERSION)
+        val javaVersion = JavaVersion.toVersion(javaTarget)
         ext.compileOptions.apply {
             // Can't use JVM toolchains yet on Android.
             sourceCompatibility = javaVersion

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -9,3 +9,7 @@ buildscript {
 allprojects {
     apply from: rootProject.file("repositories.gradle")
 }
+
+subprojects {
+    apply plugin: "org.jetbrains.kotlin.jvm"
+}

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 buildscript {
     apply from: rootProject.file("repositories.gradle"), to: buildscript
 
@@ -10,6 +12,14 @@ allprojects {
     apply from: rootProject.file("repositories.gradle")
 }
 
+final def javaTarget = Integer.parseInt(property("aditogether.jvmOptions.javaTarget"))
+final def warningsAsErrors = Boolean.valueOf(property("aditogether.jvmOptions.warningsAsErrors"))
+
 subprojects {
     apply plugin: "org.jetbrains.kotlin.jvm"
+
+    kotlin.jvmToolchain(javaTarget)
+    tasks.withType(KotlinCompile) {
+        compilerOptions.allWarningsAsErrors.set(warningsAsErrors)
+    }
 }

--- a/build-tools/common/build.gradle
+++ b/build-tools/common/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: "org.jetbrains.kotlin.jvm"
-
 dependencies {
     api gradleApi()
 }

--- a/build-tools/common/src/main/kotlin/aditogether/buildtools/utils/PropertiesUtils.kt
+++ b/build-tools/common/src/main/kotlin/aditogether/buildtools/utils/PropertiesUtils.kt
@@ -1,0 +1,31 @@
+package aditogether.buildtools.utils
+
+import groovy.lang.MissingPropertyException
+import org.gradle.api.Project
+
+/**
+ * Returns the Gradle property with the name [name] in a string format.
+ * @throws MissingPropertyException if the property is not present.
+ */
+@Throws(MissingPropertyException::class)
+fun Project.stringProperty(name: String): String = property(name).toString()
+
+/**
+ * Returns the Gradle property with the name [name] in a integer format.
+ * @throws MissingPropertyException if the property is not present or does not conform to an integer.
+ */
+@Throws(MissingPropertyException::class)
+fun Project.intProperty(name: String): Int = requireNotNull(stringProperty(name).toIntOrNull()) {
+    "The Gradle property named $name exists but is not an integer."
+}
+
+/**
+ * Returns the Gradle property with the name [name] in a integer format.
+ * @throws MissingPropertyException if the property is not present or does not conform to a boolean.
+ */
+@Throws(MissingPropertyException::class)
+fun Project.boolProperty(name: String): Boolean {
+    return requireNotNull(stringProperty(name).toBooleanStrictOrNull()) {
+        "The Gradle property named $name exists but is not a boolean."
+    }
+}

--- a/build-tools/jvm/build.gradle
+++ b/build-tools/jvm/build.gradle
@@ -1,7 +1,6 @@
 group = "aditogether.buildtools.jvm"
 
 apply plugin: "java-gradle-plugin"
-apply plugin: "org.jetbrains.kotlin.jvm"
 
 gradlePlugin {
     plugins {

--- a/build-tools/jvm/src/main/kotlin/aditogether/buildtools/jvm/JvmOptions.kt
+++ b/build-tools/jvm/src/main/kotlin/aditogether/buildtools/jvm/JvmOptions.kt
@@ -1,9 +1,0 @@
-package aditogether.buildtools.jvm
-
-/**
- * Defines the shared configuration for targets compiled with Java (e.g. JVM, Android, KMM).
- */
-object JvmOptions {
-    const val WARNINGS_AS_ERRORS: Boolean = true
-    const val JAVA_VERSION: Int = 11
-}

--- a/build-tools/jvm/src/main/kotlin/aditogether/buildtools/jvm/JvmPlugin.kt
+++ b/build-tools/jvm/src/main/kotlin/aditogether/buildtools/jvm/JvmPlugin.kt
@@ -1,6 +1,8 @@
 package aditogether.buildtools.jvm
 
 import aditogether.buildtools.utils.apply
+import aditogether.buildtools.utils.boolProperty
+import aditogether.buildtools.utils.intProperty
 import aditogether.buildtools.utils.configure
 import aditogether.buildtools.utils.withType
 import org.gradle.api.Plugin
@@ -17,12 +19,14 @@ internal class JvmPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.pluginManager.apply<KotlinPluginWrapper>()
 
+        val javaTarget = target.intProperty("aditogether.jvmOptions.javaTarget")
+        val warningsAsErrors = target.boolProperty("aditogether.jvmOptions.warningsAsErrors")
         target.tasks.withType<KotlinCompile> { task ->
-            task.compilerOptions.allWarningsAsErrors.set(JvmOptions.WARNINGS_AS_ERRORS)
+            task.compilerOptions.allWarningsAsErrors.set(warningsAsErrors)
         }
 
         target.extensions.configure<KotlinTopLevelExtension> { ext ->
-            ext.jvmToolchain(JvmOptions.JAVA_VERSION)
+            ext.jvmToolchain(javaTarget)
         }
     }
 }

--- a/build-tools/lint/build.gradle
+++ b/build-tools/lint/build.gradle
@@ -1,7 +1,6 @@
 group = "aditogether.buildtools.lint"
 
 apply plugin: "java-gradle-plugin"
-apply plugin: "org.jetbrains.kotlin.jvm"
 
 gradlePlugin {
     plugins {

--- a/build-tools/multiplatform/build.gradle
+++ b/build-tools/multiplatform/build.gradle
@@ -1,7 +1,6 @@
 group = "aditogether.buildtools.multiplatform"
 
 apply plugin: "java-gradle-plugin"
-apply plugin: "org.jetbrains.kotlin.jvm"
 
 gradlePlugin {
     plugins {

--- a/build-tools/multiplatform/build.gradle
+++ b/build-tools/multiplatform/build.gradle
@@ -13,6 +13,5 @@ gradlePlugin {
 
 dependencies {
     implementation project(':common')
-    implementation project(':jvm')
     implementation libs.gradle.kotlin
 }

--- a/build-tools/multiplatform/src/main/kotlin/aditogether/buildtools/multiplatform/MultiPlatformPlugin.kt
+++ b/build-tools/multiplatform/src/main/kotlin/aditogether/buildtools/multiplatform/MultiPlatformPlugin.kt
@@ -1,8 +1,9 @@
 package aditogether.buildtools.multiplatform
 
-import aditogether.buildtools.jvm.JvmOptions
 import aditogether.buildtools.utils.apply
+import aditogether.buildtools.utils.boolProperty
 import aditogether.buildtools.utils.configure
+import aditogether.buildtools.utils.intProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -21,16 +22,25 @@ internal class MultiPlatformPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.pluginManager.apply<KotlinMultiplatformPluginWrapper>()
 
+        val javaTarget = target.intProperty("aditogether.jvmOptions.javaTarget")
+        val warningsAsErrors = target.boolProperty("aditogether.jvmOptions.warningsAsErrors")
+
         target.extensions.configure<KotlinMultiplatformExtension> { ext ->
-            ext.targetFromPreset(KotlinJvmTargetPreset(target), ::configureJvmTarget)
+            ext.targetFromPreset(KotlinJvmTargetPreset(target)) {
+                configureJvmTarget(this, javaTarget, warningsAsErrors)
+            }
         }
     }
 
-    private fun configureJvmTarget(target: KotlinJvmTarget) {
+    private fun configureJvmTarget(
+        target: KotlinJvmTarget,
+        javaTarget: Int,
+        warningsAsErrors: Boolean
+    ) {
         target.compilations.all { compilation ->
             compilation.compilerOptions.configure {
-                allWarningsAsErrors.set(JvmOptions.WARNINGS_AS_ERRORS)
-                jvmTarget.set(JvmTarget.fromTarget(JvmOptions.JAVA_VERSION.toString()))
+                allWarningsAsErrors.set(warningsAsErrors)
+                jvmTarget.set(JvmTarget.fromTarget(javaTarget.toString()))
             }
         }
     }

--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 rootProject.name = 'build-tools'
 
 include 'android'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,12 @@
 # The original file is in the root project and it's symlinked in build-tools to
 # provide the same properties to the included build.
 
+#======= Generic settings =======#
 kotlin.incremental.useClasspathSnapshot=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx3g
 org.gradle.parallel=true
+
+#======= Project specific settings =======#
+aditogether.jvmOptions.javaTarget=11
+aditogether.jvmOptions.warningsAsErrors=true


### PR DESCRIPTION
This PR creates a shared configuration for our build-tools Gradle modules.
This helps in applying also some code quality rules like `allWarningsAsErrors` and the same Java version across all the build-tools modules.

**Important**: currently the `settings.gradle` plugins aren't shared (it's not immediate to do it since they are not project plugins), but I opened the issue https://github.com/androiddevelopersitalia/aditogether/issues/65 to this separately

