### PR TITLE
Use plugins id convention instead of legacy one

### DIFF
--- a/build-tools/android/build.gradle
+++ b/build-tools/android/build.gradle
@@ -1,6 +1,8 @@
-group = "aditogether.buildtools.android"
+plugins {
+    id "java-gradle-plugin"
+}
 
-apply plugin: "java-gradle-plugin"
+group = "aditogether.buildtools.android"
 
 gradlePlugin {
     plugins {

--- a/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidPlugin.kt
+++ b/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidPlugin.kt
@@ -25,7 +25,7 @@ internal class AndroidPlugin : Plugin<Project> {
         target.tasks.withType<KotlinCompile> { task ->
             // Can't use JVM toolchains yet on Android.
             task.compilerOptions {
-                jvmTarget.set(JvmTarget.valueOf(javaTarget.toString()))
+                jvmTarget.set(JvmTarget.fromTarget(javaTarget.toString()))
                 allWarningsAsErrors.set(warningsAsErrors)
             }
         }

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -1,15 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-buildscript {
-    apply from: rootProject.file("repositories.gradle"), to: buildscript
-
-    dependencies {
-        classpath libs.gradle.kotlin
-    }
-}
-
-allprojects {
-    apply from: rootProject.file("repositories.gradle")
+plugins {
+    alias(libs.plugins.kotlin.jvm) apply false
 }
 
 final def javaTarget = Integer.parseInt(property("aditogether.jvmOptions.javaTarget"))

--- a/build-tools/dependency-management.gradle
+++ b/build-tools/dependency-management.gradle
@@ -1,0 +1,6 @@
+dependencyResolutionManagement {
+    apply from: "repositories.gradle"
+    configureRepositories(repositories)
+
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+}

--- a/build-tools/jvm/build.gradle
+++ b/build-tools/jvm/build.gradle
@@ -1,6 +1,8 @@
-group = "aditogether.buildtools.jvm"
+plugins {
+    id "java-gradle-plugin"
+}
 
-apply plugin: "java-gradle-plugin"
+group = "aditogether.buildtools.jvm"
 
 gradlePlugin {
     plugins {

--- a/build-tools/lint/build.gradle
+++ b/build-tools/lint/build.gradle
@@ -1,6 +1,8 @@
-group = "aditogether.buildtools.lint"
+plugins {
+    id "java-gradle-plugin"
+}
 
-apply plugin: "java-gradle-plugin"
+group = "aditogether.buildtools.lint"
 
 gradlePlugin {
     plugins {

--- a/build-tools/multiplatform/build.gradle
+++ b/build-tools/multiplatform/build.gradle
@@ -1,6 +1,8 @@
-group = "aditogether.buildtools.multiplatform"
+plugins {
+    id "java-gradle-plugin"
+}
 
-apply plugin: "java-gradle-plugin"
+group = "aditogether.buildtools.multiplatform"
 
 gradlePlugin {
     plugins {

--- a/build-tools/plugin-management.gradle
+++ b/build-tools/plugin-management.gradle
@@ -1,0 +1,6 @@
+def currentJavaVersion = JavaVersion.current()
+if (!currentJavaVersion.isJava11Compatible()) {
+    throw new IllegalArgumentException("Java 11 is needed to compile the project. Current: $currentJavaVersion.")
+}
+apply from: "repositories.gradle"
+configureRepositories(repositories)

--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -1,0 +1,4 @@
+ext.configureRepositories = { RepositoryHandler repositories ->
+    repositories.google()
+    repositories.gradlePluginPortal()
+}

--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -1,4 +1,0 @@
-repositories {
-    mavenCentral()
-    google()
-}

--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -1,17 +1,15 @@
+pluginManagement {
+    apply from: "plugin-management.gradle", to: pluginManagement
+}
+
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
 }
 
-dependencyResolutionManagement {
-    repositories {
-        google()
-        gradlePluginPortal()
-    }
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+apply from: "dependency-management.gradle"
 
-    versionCatalogs {
-        libs.from files("../gradle/libs.versions.toml")
-    }
+dependencyResolutionManagement.versionCatalogs {
+    libs.from files("../gradle/libs.versions.toml")
 }
 
 rootProject.name = 'build-tools'

--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -2,6 +2,18 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
 }
 
+dependencyResolutionManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+    }
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+
+    versionCatalogs {
+        libs.from files("../gradle/libs.versions.toml")
+    }
+}
+
 rootProject.name = 'build-tools'
 
 include 'android'
@@ -9,11 +21,3 @@ include 'common'
 include 'jvm'
 include 'lint'
 include 'multiplatform'
-
-dependencyResolutionManagement {
-    versionCatalogs {
-        libs {
-            from files("../gradle/libs.versions.toml")
-        }
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,13 @@
-buildscript {
-    apply from: rootProject.file("build-tools/repositories.gradle"), to: buildscript
-
-    dependencies {
-        classpath libs.gradle.android
-        classpath libs.gradle.kotlin
-        classpath libs.gradle.aditogether.android
-        classpath libs.gradle.aditogether.jvm
-        classpath libs.gradle.aditogether.lint
-        classpath libs.gradle.aditogether.multiplatform
-    }
+plugins {
+    alias(libs.plugins.aditogether.lint) apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.multiplatform) apply false
 }
 
 allprojects {
-    apply from: rootProject.file("build-tools/repositories.gradle")
     apply plugin: "aditogether.lint"
 }
 

--- a/detekt/rules/build.gradle
+++ b/detekt/rules/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: "aditogether.jvm"
+plugins {
+    alias(libs.plugins.aditogether.jvm)
+}
 
 dependencies {
     compileOnly(libs.detekt.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,15 +55,22 @@ ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
 
-gradle-aditogether-android = { module = "aditogether.buildtools.android:android" }
-gradle-aditogether-jvm = { module = "aditogether.buildtools.jvm:jvm" }
-gradle-aditogether-lint = { module = "aditogether.buildtools.lint:lint" }
-gradle-aditogether-multiplatform = { module = "aditogether.buildtools.multiplatform:multiplatform" }
-gradle-android = { module = "com.android.tools.build:gradle", version.ref = "gradleAndroidPlugin" }
 gradle-android-api = { module = "com.android.tools.build:gradle-api", version.ref = "gradleAndroidPlugin" }
 gradle-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 gradle-kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
+
+[plugins]
+aditogether-android-app = { id = "aditogether.android.app", version = "?" }
+aditogether-android-library = { id = "aditogether.android.library", version = "?" }
+aditogether-jvm = { id = "aditogether.jvm", version = "?" }
+aditogether-lint = { id = "aditogether.lint", version = "?" }
+aditogether-multiplatform = { id = "aditogether.multiplatform", version = "?" }
+android-application = { id = "com.android.application", version.ref = "gradleAndroidPlugin" }
+android-library = { id = "com.android.library", version.ref = "gradleAndroidPlugin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 
 [bundles]
 # TBD

--- a/playground/build.gradle
+++ b/playground/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: "aditogether.jvm"
+plugins {
+    alias(libs.plugins.aditogether.jvm)
+}
 
 dependencies {
     testImplementation libs.kotest.assertions

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,10 +3,22 @@ pluginManagement {
     if (!currentJavaVersion.isJava11Compatible()) {
         throw new IllegalArgumentException("Java 11 is needed to compile the project. Current: $currentJavaVersion.")
     }
+    repositories {
+        google()
+        gradlePluginPortal()
+    }
 }
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+    }
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 }
 
 rootProject.name = "aditogether"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,25 +1,12 @@
 pluginManagement {
-    def currentJavaVersion = JavaVersion.current()
-    if (!currentJavaVersion.isJava11Compatible()) {
-        throw new IllegalArgumentException("Java 11 is needed to compile the project. Current: $currentJavaVersion.")
-    }
-    repositories {
-        google()
-        gradlePluginPortal()
-    }
+    apply from: "build-tools/plugin-management.gradle", to: pluginManagement
 }
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
 }
 
-dependencyResolutionManagement {
-    repositories {
-        google()
-        gradlePluginPortal()
-    }
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-}
+apply from: "build-tools/dependency-management.gradle"
 
 rootProject.name = "aditogether"
 


### PR DESCRIPTION
This PR updates the plugin convention used in this project from the legacy one to the `id` one.

I know I proposed to use the legacy convention since the new one has some limitations but I changed my mind for the following reasons:
1. This project should show an up-to-date approach using new tools and the `id` convention is a standard from now on
2. Users who don't care at all about the build logic, would find the `id` convention more useful, since all the latest samples are written using the plugin `id` convention
3. This is not a huge enterprise app so probably the limitations of the plugin id convention will never arise (and if they do, we can apply some workaround to fix them)

This is a proposal, what do you think @4face-studi0 @mcatta ?
I'd like to hear the opinions of you both