### PR TITLE
Add Compose plugins

### DIFF
--- a/build-tools/android/build.gradle
+++ b/build-tools/android/build.gradle
@@ -8,6 +8,10 @@ gradlePlugin {
             id = 'aditogether.android.app'
             implementationClass = 'aditogether.buildtools.android.AndroidAppPlugin'
         }
+        compose {
+            id = 'aditogether.android.compose'
+            implementationClass = 'aditogether.buildtools.android.AndroidComposePlugin'
+        }
         library {
             id = 'aditogether.android.library'
             implementationClass = 'aditogether.buildtools.android.AndroidLibraryPlugin'

--- a/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidComposePlugin.kt
+++ b/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidComposePlugin.kt
@@ -7,6 +7,10 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 
+/**
+ * Applies Jetpack Compose configuration to Android targets.
+ */
+@Suppress("unused")
 internal class AndroidComposePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {

--- a/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidComposePlugin.kt
+++ b/build-tools/android/src/main/kotlin/aditogether/buildtools/android/AndroidComposePlugin.kt
@@ -1,0 +1,23 @@
+package aditogether.buildtools.android
+
+import aditogether.buildtools.utils.configure
+import aditogether.buildtools.utils.libsCatalog
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalog
+
+internal class AndroidComposePlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        val libsCatalog = target.libsCatalog
+        target.extensions.configure<CommonExtension<*, *, *, *>> { ext -> configureComposeOptions(libsCatalog, ext) }
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun configureComposeOptions(libsCatalog: VersionCatalog, ext: CommonExtension<*, *, *, *>) {
+        ext.buildFeatures.compose = true
+        ext.composeOptions.kotlinCompilerExtensionVersion =
+            libsCatalog.findVersion("androidxComposeCompiler").get().toString()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 androidxActivity = "1.6.1"
 androidxComposeBom = "2023.01.00"
+androidxComposeCompiler = "1.4.3"
 androidxCore = "1.9.0"
 androidxLifecycle = "2.5.1"
 detekt = "1.22.0"


### PR DESCRIPTION
This PR makes the Project Compose-ready by:
* adding Compose to the `AndroidAppPlugin`, now `AndroidComposeAppPlugin` (id `aditogether.android.app` -> `aditogheter.android.compose.app`)
* adding `AndroidComposeLibraryPlugin` (id `aditogether.android.compose.library`)