### PR TITLE
Setup Android in Playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ local.properties
 
 # IntelliJ
 .idea/.name
+.idea/assetWizardSettings.xml
 .idea/codeStyles
 .idea/compiler.xml
 .idea/gradle.xml

--- a/build-tools/android/build.gradle
+++ b/build-tools/android/build.gradle
@@ -10,7 +10,7 @@ gradlePlugin {
             id = 'aditogether.android.app'
             implementationClass = 'aditogether.buildtools.android.AndroidAppPlugin'
         }
-        compose {
+        composePlugin {
             id = 'aditogether.android.compose'
             implementationClass = 'aditogether.buildtools.android.AndroidComposePlugin'
         }

--- a/build-tools/android/build.gradle
+++ b/build-tools/android/build.gradle
@@ -6,7 +6,7 @@ group = "aditogether.buildtools.android"
 
 gradlePlugin {
     plugins {
-        app {
+        appPlugin {
             id = 'aditogether.android.app'
             implementationClass = 'aditogether.buildtools.android.AndroidAppPlugin'
         }
@@ -14,7 +14,7 @@ gradlePlugin {
             id = 'aditogether.android.compose'
             implementationClass = 'aditogether.buildtools.android.AndroidComposePlugin'
         }
-        library {
+        libraryPlugin {
             id = 'aditogether.android.library'
             implementationClass = 'aditogether.buildtools.android.AndroidLibraryPlugin'
         }

--- a/build-tools/jvm/build.gradle
+++ b/build-tools/jvm/build.gradle
@@ -6,9 +6,8 @@ group = "aditogether.buildtools.jvm"
 
 gradlePlugin {
     plugins {
-        jvm {
+        jvmPlugin {
             id = 'aditogether.jvm'
-            displayName = 'AdiTogether JVM Plugin'
             implementationClass = 'aditogether.buildtools.jvm.JvmPlugin'
         }
     }

--- a/build-tools/lint/build.gradle
+++ b/build-tools/lint/build.gradle
@@ -6,10 +6,8 @@ group = "aditogether.buildtools.lint"
 
 gradlePlugin {
     plugins {
-        lint {
+        lintPlugin {
             id = 'aditogether.lint'
-            displayName = 'AdiTogether Lint Plugin'
-            description = 'Setup Linters for the project'
             implementationClass = 'aditogether.buildtools.lint.LintPlugin'
         }
     }

--- a/build-tools/multiplatform/build.gradle
+++ b/build-tools/multiplatform/build.gradle
@@ -6,7 +6,7 @@ group = "aditogether.buildtools.multiplatform"
 
 gradlePlugin {
     plugins {
-        multiplatform {
+        multiplatformPlugin {
             id = 'aditogether.multiplatform'
             implementationClass = 'aditogether.buildtools.multiplatform.MultiPlatformPlugin'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@
 # provide the same properties to the included build.
 
 #======= Generic settings =======#
+android.useAndroidX=true
 kotlin.incremental.useClasspathSnapshot=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx3g

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,6 @@ ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref
 gradle-android-api = { module = "com.android.tools.build:gradle-api", version.ref = "gradleAndroidPlugin" }
 gradle-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-gradle-kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 gradle-toolchains = { module = "org.gradle.toolchains:foojay-resolver", version.ref = "gradleToolchains" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,6 @@ ktor = "2.2.3"
 [libraries]
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 
-androidx-compose-activity = { group = "androidx.activity", name = "activity-compose" }
 androidx-compose-material = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-navigation = { group = "androidx.navigation", name = "navigation-compose" }
 androidx-compose-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
@@ -28,7 +27,8 @@ androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-uiTest = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-uiTest-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
-androidx-activity = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
+androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidxActivity" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewModel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
 androidx-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
@@ -65,6 +65,7 @@ gradle-toolchains = { module = "org.gradle.toolchains:foojay-resolver", version.
 
 [plugins]
 aditogether-android-app = { id = "aditogether.android.app", version = "?" }
+aditogether-android-compose = { id = "aditogether.android.compose", version = "?" }
 aditogether-android-library = { id = "aditogether.android.library", version = "?" }
 aditogether-jvm = { id = "aditogether.jvm", version = "?" }
 aditogether-lint = { id = "aditogether.lint", version = "?" }

--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -1,5 +1,9 @@
 plugins {
-    alias(libs.plugins.aditogether.jvm)
+    alias(libs.plugins.aditogether.android.app)
+}
+
+android {
+    namespace 'aditogether.playground.android'
 }
 
 dependencies {

--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.aditogether.android.app)
+    alias(libs.plugins.aditogether.android.compose)
 }
 
 android {
@@ -7,6 +8,10 @@ android {
 }
 
 dependencies {
+    implementation platform(libs.androidx.compose.bom)
+    implementation libs.androidx.activity.compose
+    implementation libs.androidx.compose.material
+
     testImplementation libs.kotest.assertions
     testImplementation libs.kotest.runner
 }

--- a/playground/android/src/main/AndroidManifest.xml
+++ b/playground/android/src/main/AndroidManifest.xml
@@ -1,6 +1,14 @@
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application>
+    <application android:name=".PlaygroundApplication">
+
+        <activity android:name=".PlaygroundActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
 
     </application>
 

--- a/playground/android/src/main/AndroidManifest.xml
+++ b/playground/android/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest>
+
+    <application>
+
+    </application>
+
+</manifest>

--- a/playground/android/src/main/AndroidManifest.xml
+++ b/playground/android/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:name=".PlaygroundApplication">
+    <application android:name=".PlaygroundApplication"
+        android:icon="@mipmap/ic_launcher">
 
         <activity android:name=".PlaygroundActivity"
             android:exported="true">

--- a/playground/android/src/main/kotlin/aditogether/playground/android/PlaygroundActivity.kt
+++ b/playground/android/src/main/kotlin/aditogether/playground/android/PlaygroundActivity.kt
@@ -1,0 +1,14 @@
+package aditogether.playground.android
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.Text
+
+class PlaygroundActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { Text(text = "Hello ADI") }
+    }
+}

--- a/playground/android/src/main/kotlin/aditogether/playground/android/PlaygroundApplication.kt
+++ b/playground/android/src/main/kotlin/aditogether/playground/android/PlaygroundApplication.kt
@@ -1,0 +1,5 @@
+package aditogether.playground.android
+
+import android.app.Application
+
+class PlaygroundApplication : Application()

--- a/playground/android/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/playground/android/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+  <group android:scaleX="0.5684"
+      android:scaleY="0.5684"
+      android:translateX="5.1792"
+      android:translateY="5.1792">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,16.5l6,-4.5 -6,-4.5v9zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
+  </group>
+</vector>

--- a/playground/android/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/playground/android/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/playground/android/src/main/res/values/ic_launcher_background.xml
+++ b/playground/android/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#08CC40</color>
+</resources>

--- a/playground/multiplatform/build.gradle
+++ b/playground/multiplatform/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    alias(libs.plugins.aditogether.jvm)
+}
+
+dependencies {
+    testImplementation libs.kotest.assertions
+    testImplementation libs.kotest.runner
+}

--- a/playground/multiplatform/src/main/kotlin/aditogether/playground/multiplatform/DetektPlayground.kt
+++ b/playground/multiplatform/src/main/kotlin/aditogether/playground/multiplatform/DetektPlayground.kt
@@ -1,6 +1,6 @@
 @file:Suppress("unused")
 
-package aditogether.playground
+package aditogether.playground.multiplatform
 
 fun test() = Constant
 

--- a/playground/multiplatform/src/test/kotlin/aditogether/playground/multiplatform/KotestPlaygroundTest.kt
+++ b/playground/multiplatform/src/test/kotlin/aditogether/playground/multiplatform/KotestPlaygroundTest.kt
@@ -1,4 +1,4 @@
-package aditogether.playground.test
+package aditogether.playground.multiplatform
 
 import io.kotest.core.spec.style.BehaviorSpec
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,4 +14,4 @@ apply from: "build-tools/dependency-management.gradle"
 rootProject.name = "aditogether"
 
 include 'detekt:rules'
-include 'playground'
+include 'playground:multiplatform'

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,4 +14,5 @@ apply from: "build-tools/dependency-management.gradle"
 rootProject.name = "aditogether"
 
 include 'detekt:rules'
+include 'playground:android'
 include 'playground:multiplatform'


### PR DESCRIPTION
This PR creates 2 sub-modules in `playground`:
* Android
* Multiplatform

Android module contains a simple Application and Activity (Compose)

Also, a small bug has been fixed:
Inside the `plugin` block of Android plugins' `build.gradle` file we used `compose`, but it seems like `compose` is a existent function in Gradle, so it has been replaced by `composePlugin`

Closes #67 