### PR TITLE
Share `settings.gradle` plugins between composite builds

### DIFF
--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -1,9 +1,11 @@
 pluginManagement {
     apply from: "plugin-management.gradle", to: pluginManagement
+
+    includeBuild 'settings'
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+    id "aditogether.settings"
 }
 
 apply from: "dependency-management.gradle"

--- a/build-tools/settings/build.gradle
+++ b/build-tools/settings/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id "groovy"
+    id "java-gradle-plugin"
+}
+
+group = "aditogether.buildtools.settings"
+
+gradlePlugin {
+    plugins {
+        settingsPlugin {
+            id = "aditogether.settings"
+            implementationClass = "aditogether.buildtools.settings.SettingsPlugin"
+        }
+    }
+}
+
+dependencies {
+    api gradleApi()
+
+    implementation localGroovy()
+    implementation libs.gradle.toolchains
+}

--- a/build-tools/settings/settings.gradle
+++ b/build-tools/settings/settings.gradle
@@ -1,0 +1,7 @@
+apply from: "../dependency-management.gradle"
+
+dependencyResolutionManagement.versionCatalogs {
+    libs.from files("../../gradle/libs.versions.toml")
+}
+
+rootProject.name = "settings"

--- a/build-tools/settings/src/main/groovy/aditogether/buildtools/settings/SettingsPlugin.groovy
+++ b/build-tools/settings/src/main/groovy/aditogether/buildtools/settings/SettingsPlugin.groovy
@@ -1,0 +1,15 @@
+package aditogether.buildtools.settings
+
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+
+/**
+ * Applies and configures the same plugins to our settings.gradle files.
+ */
+@SuppressWarnings('unused')
+class SettingsPlugin implements Plugin<Settings> {
+    @Override
+    void apply(Settings target) {
+        target.apply plugin: "org.gradle.toolchains.foojay-resolver-convention"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ androidxLifecycle = "2.5.1"
 detekt = "1.22.0"
 detektRulesCompose = "0.0.26"
 gradleAndroidPlugin = "7.4.1"
+gradleToolchains = "0.4.0"
 koin = "3.3.3"
 koinAnnotation = "1.1.1"
 koinCompose = "3.4.2"
@@ -60,6 +61,7 @@ gradle-android-api = { module = "com.android.tools.build:gradle-api", version.re
 gradle-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 gradle-kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
+gradle-toolchains = { module = "org.gradle.toolchains:foojay-resolver", version.ref = "gradleToolchains" }
 
 [plugins]
 aditogether-android-app = { id = "aditogether.android.app", version = "?" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,16 +1,17 @@
 pluginManagement {
     apply from: "build-tools/plugin-management.gradle", to: pluginManagement
+
+    includeBuild "build-tools/settings"
+    includeBuild "build-tools"
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+    id "aditogether.settings"
 }
 
 apply from: "build-tools/dependency-management.gradle"
 
 rootProject.name = "aditogether"
-
-includeBuild 'build-tools'
 
 include 'detekt:rules'
 include 'playground'


### PR DESCRIPTION
This PR shares the configuration of our JDK toolchain resolver moving the version in our Version Catalog and creating a composite build which provides a `Settings` plugin (not a `Project` ones).

_Why `SettingsPlugin` is in Groovy rather than Kotlin?_
We could have it in Kotlin but this means that we need to apply our Kotlin config to this new module from scratch, since it can't access any of our Kotlin shared config.
To do something simple like this, Groovy is way easier to maintain since it's shipped with Gradle so we don't need any custom config.

_How can we access the Version Catalog now but we couldn't before?_"
This happens because the Version Catalog is just a file which is provided **after** the settings.gradle plugins are resolved.
Now, this plugin is applied inside **settings.gradle** of the other projects ("aditogether" and "build-tools") but the Version Catalog is accessed only inside our **build.gradle** files.
TL;DR: Version Catalog is still not accessible by plugins in **settings.gradle** but now there's no need to since it's only references in **build.gradle** files.

Closes: https://github.com/androiddevelopersitalia/aditogether/issues/65